### PR TITLE
change font path variable name. use !default

### DIFF
--- a/pe-icon-7-stroke/scss/_path.scss
+++ b/pe-icon-7-stroke/scss/_path.scss
@@ -1,10 +1,10 @@
 @font-face {
 	font-family: 'Pe-icon-7-stroke';
-	src:url('#{$font-path}/Pe-icon-7-stroke.eot?d7yf1v');
-	src:url('#{$font-path}/Pe-icon-7-stroke.eot?#iefixd7yf1v') format('embedded-opentype'),
-		url('#{$font-path}/Pe-icon-7-stroke.woff?d7yf1v') format('woff'),
-		url('#{$font-path}/Pe-icon-7-stroke.ttf?d7yf1v') format('truetype'),
-		url('#{$font-path}/Pe-icon-7-stroke.svg?d7yf1v#Pe-icon-7-stroke') format('svg');
+	src:url('#{$pe-7s-font-path}/Pe-icon-7-stroke.eot?d7yf1v');
+	src:url('#{$pe-7s-font-path}/Pe-icon-7-stroke.eot?#iefixd7yf1v') format('embedded-opentype'),
+		url('#{$pe-7s-font-path}/Pe-icon-7-stroke.woff?d7yf1v') format('woff'),
+		url('#{$pe-7s-font-path}/Pe-icon-7-stroke.ttf?d7yf1v') format('truetype'),
+		url('#{$pe-7s-font-path}/Pe-icon-7-stroke.svg?d7yf1v#Pe-icon-7-stroke') format('svg');
 	font-weight: normal;
 	font-style: normal;
 }

--- a/pe-icon-7-stroke/scss/_variables.scss
+++ b/pe-icon-7-stroke/scss/_variables.scss
@@ -1,6 +1,6 @@
 $pe-7s-font-path: "../fonts" !default;
-$font-size-base: 1em;
-$font-prefix: "pe-7s";
+$font-size-base: 1em !default;
+$font-prefix: "pe-7s" !default;
 
 $font-var-album: "\e6aa";
 $font-var-arc: "\e6ab";

--- a/pe-icon-7-stroke/scss/_variables.scss
+++ b/pe-icon-7-stroke/scss/_variables.scss
@@ -1,4 +1,4 @@
-$font-path: "../fonts";
+$pe-7s-font-path: "../fonts" !default;
 $font-size-base: 1em;
 $font-prefix: "pe-7s";
 


### PR DESCRIPTION
Two things:
- use `!default` so we can override the variable in our apps. This is what other fonts like FontAwesome do
- change `$font-path` variable name to `$pe-7s-font-path`. This avoids collisions since `$font-path` is a rather generic name.
